### PR TITLE
feat: adjust chart y-axis to be more 🏒

### DIFF
--- a/src/common/InfoDashboard/const.ts
+++ b/src/common/InfoDashboard/const.ts
@@ -40,8 +40,7 @@ export const CHART_CONFIG: Readonly<ChartConfig> = Object.freeze({
         },
         ticks: {
           color: '#ffffff',
-          callback: (val: unknown) => String(val).replace(/000$/, 'K'),
-          stepSize: 5000,
+          stepSize: 50,
         },
       },
     },


### PR DESCRIPTION
Small tweak to make the chart look like this:
<img width="560" alt="new" src="https://github.com/Nounspace/space-dashboard/assets/37815163/52748be9-52e8-4115-ba6e-004059c9b7d7">

vs. this:
<img width="703" alt="old" src="https://github.com/Nounspace/space-dashboard/assets/37815163/d853ed2b-d4da-4370-bc06-5347d1385de2">



