### PR TITLE
fix: change depost modal warning text to black

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,6 @@ import { useNotifications } from '@/composables'
 import { bus, BUS_EVENTS, ErrorHandler } from '@/helpers'
 import { useWeb3ProvidersStore } from '@/store'
 import { type NotificationPayload } from '@/types'
-import { config } from '@config'
 import { ref } from 'vue'
 
 const isAppInitialized = ref(false)

--- a/src/fields/InputField.vue
+++ b/src/fields/InputField.vue
@@ -361,6 +361,10 @@ $z-index-side-nodes: 1;
   @include field-msg-icon;
 }
 
+.input-field__err-msg {
+  color: black !important;
+}
+
 .input-field__err-msg,
 .input-field__note-msg {
   @include field-error;


### PR DESCRIPTION
![Screenshot 2024-06-20 at 10 43 54 PM](https://github.com/Nounspace/space-dashboard/assets/37815163/59417255-d31a-474b-9c0a-69a5e3746d59)
